### PR TITLE
add medaka_fastq option

### DIFF
--- a/NGSpeciesID
+++ b/NGSpeciesID
@@ -207,6 +207,7 @@ if __name__ == '__main__':
     group.add_argument('--racon', action="store_true", help='Run final racon polishing algorithm.')
 
     parser.add_argument('--medaka_model', type=str, default="", help='Set specific medaka model.')
+    parser.add_argument('--medaka_fastq', action="store_true", help='Request Medaka to output a FASTQ file, instead of FASTA')
     parser.add_argument('--racon_iter', type=int, default=2, help='Number of times to run racon iteratively')
 
     group2 = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
Add support the -q option of Medaka, a recent feature that makes the medaka_consensus script to produce a FASTQ  file instead of a FASTA file, so with the per-base qualities. #26

