### PR TITLE
Add --symmetric_map_align_thresholds option

### DIFF
--- a/NGSpeciesID
+++ b/NGSpeciesID
@@ -103,7 +103,7 @@ def main(args):
     output_cl_id = 0
     for c_id, all_read_acc in sorted(clusters.items(), key = lambda x: (len(x[1]),representatives[x[0]][5]), reverse=True):
     # for c_id, all_read_acc in sorted(clusters.items(), key = lambda x: (len(x[1]),x[0]), reverse=True):
-        read_cl_id, b_i, acc, c_seq, c_qual, score, error_rate = representatives[c_id]
+        read_cl_id, b_i, acc, c_seq, c_qual, score, error_rate, _ = representatives[c_id]
         origins_outfile.write("{0}\t{1}\t{2}\t{3}\t{4}\t{5}\n".format(output_cl_id, "_".join([item for item in acc.split("_")[:-1]]), c_seq, c_qual, score, error_rate))
 
         for r_acc in sorted(all_read_acc, key = lambda x: float(x.split("_")[-1]) , reverse=True):
@@ -228,6 +228,7 @@ if __name__ == '__main__':
     parser.add_argument('--min_shared', type=int, default=5, help='Minmum number of minimizers shared between read and cluster')
     parser.add_argument('--mapped_threshold', type=float, default=0.7, help='Minmum mapped fraction of read to be included in cluster. The density of minimizers to classify a region as mapped depends on quality of the read.')
     parser.add_argument('--aligned_threshold', type=float, default=0.4, help='Minmum aligned fraction of read to be included in cluster. Aligned identity depends on the quality of the read.')
+    parser.add_argument('--symmetric_map_align_thresholds', action='store_true', help='Apply mapped threshold and aligned threshold to fraction of cluster representative which maps onto the read')
     parser.add_argument('--batch_type', type=str, default='total_nt', help='In parrallel mode, how to split the reads into chunks "total_nt", "nr_reads", or "weighted" (default: total_nt) ')
     parser.add_argument('--min_fraction', type=float, default=0.8, help='Minmum fraction of minimizers shared compared to best hit, in order to continue mapping.')
     parser.add_argument('--min_prob_no_hits', type=float, default=0.1, help='Minimum probability for i consecutive minimizers to be different between read and representative and still considered as mapped region, under assumption that they come from the same transcript (depends on read quality).')

--- a/modules/cluster.py
+++ b/modules/cluster.py
@@ -93,8 +93,8 @@ def get_best_cluster(read_cl_id, compressed_seq_len, hit_clusters_ids, hit_clust
                 minimizer_hit_positions = hit_clusters_hit_positions[cl_id]
                 minimizer_hit_indices = hit_clusters_hit_index[cl_id]
                 assert len(minimizer_hit_indices) == len(minimizer_hit_positions)
-                _, _, _, _, _, _, error_rate_c = representatives[cl_id]
-                _, _, _, _, _, _, error_rate_read = representatives[read_cl_id]
+                _, _, _, _, _, _, error_rate_c, rep_compressed_seq = representatives[cl_id]
+                _, _, _, _, _, _, error_rate_read, _ = representatives[read_cl_id]
                 p_error_in_kmers_emp =  1.0 - p_shared_minimizer_empirical(error_rate_read, error_rate_c, p_emp_probs)
                 minimizer_error_probabilities = [p_error_in_kmers_emp]*nummber_of_minimizers
                 total_mapped = 0
@@ -115,13 +115,17 @@ def get_best_cluster(read_cl_id, compressed_seq_len, hit_clusters_ids, hit_clust
                 else:
                     total_mapped += compressed_seq_len - minimizer_hit_positions[-1]
 
-                mapped_ratio = total_mapped /float(compressed_seq_len) 
-                
-                if mapped_ratio > args.mapped_threshold:
-                    # is_covered = True
+                mapped_ratio = total_mapped /float(compressed_seq_len)
+
+                # Calculate the ratio of mapped region of the representative
+                rep_mapped_ratio = total_mapped / float(len(rep_compressed_seq))
+
+                if args.symmetric_map_align_thresholds and min(mapped_ratio, rep_mapped_ratio) > args.mapped_threshold:
+                    return cl_id, nm_hits, mapped_ratio
+                elif not args.symmetric_map_align_thresholds and mapped_ratio > args.mapped_threshold:
                     return cl_id, nm_hits, mapped_ratio
 
-    return  best_cluster_id, nr_shared_kmers, mapped_ratio 
+    return best_cluster_id, nr_shared_kmers, mapped_ratio
 
 
 def parasail_block_alignment(s1, s2, k, match_id, match_score = 2, mismatch_penalty = -2, opening_penalty = 5, gap_ext = 1):
@@ -164,13 +168,14 @@ def parasail_block_alignment(s1, s2, k, match_id, match_score = 2, mismatch_pena
     # print("".join([str(m) for m in aligned_region]))
     # print("Aligned ratio (tot aligned/len(seq1):", sum(aligned_region)/float(len(s1)))
     alignment_ratio = sum(aligned_region)/float(len(s1))
-    return (s1, s2, (s1_alignment, s2_alignment, alignment_ratio))
+    target_alignment_ratio = sum(aligned_region)/float(len(s2))
+    return (s1, s2, (s1_alignment, s2_alignment, alignment_ratio, target_alignment_ratio))
 
 
 def get_best_cluster_block_align(read_cl_id, representatives, hit_clusters_ids, hit_clusters_hit_positions, phred_char_to_p, args):
     best_cluster_id = -1
     top_matches = sorted(hit_clusters_hit_positions.items(), key=lambda x: (len(x[1]), sum(x[1]), representatives[x[0]][2]),  reverse=True) #sorted(hit_clusters_ids.items(), key=lambda x: x[1],  reverse=True)
-    _, _, _, seq, r_qual, _, _ = representatives[read_cl_id]
+    _, _, _, seq, r_qual, _, _, _ = representatives[read_cl_id]
     # print(top_matches)
     top_hits = len(top_matches[0][1])
     alignment_ratio = 0.0
@@ -179,7 +184,7 @@ def get_best_cluster_block_align(read_cl_id, representatives, hit_clusters_ids, 
         nm_hits = len(tm[1])
         if nm_hits < top_hits:
             break
-        _, _, _, c_seq, c_qual, _, _ = representatives[cl_id]
+        _, _, _, c_seq, c_qual, _, _, _ = representatives[cl_id]
 
         poisson_mean = sum([ r_qual.count(char_) * phred_char_to_p[char_] for char_ in set(r_qual)])
         poisson_mean2 = sum([ c_qual.count(char_) * phred_char_to_p[char_] for char_ in set(c_qual)])
@@ -195,11 +200,13 @@ def get_best_cluster_block_align(read_cl_id, representatives, hit_clusters_ids, 
             gap_opening_penalty = 2
 
         match_id_tailored = math.floor((1.0 - error_rate_sum) * args.k)
-        (s1, s2, (s1_alignment, s2_alignment, alignment_ratio)) = parasail_block_alignment(seq, c_seq, args.k, match_id_tailored, opening_penalty = gap_opening_penalty,  )
+        (s1, s2, (s1_alignment, s2_alignment, alignment_ratio, target_alignment_ratio)) = parasail_block_alignment(seq, c_seq, args.k, match_id_tailored, opening_penalty = gap_opening_penalty,  )
         # print("Expected errors:", poisson_mean, poisson_mean2)
-        if alignment_ratio >= args.aligned_threshold: #args.mapped_threshold:
+        if args.symmetric_map_align_thresholds and min(alignment_ratio, target_alignment_ratio) >= args.aligned_threshold:
             return cl_id, nm_hits,  error_rate_sum, s1_alignment, s2_alignment, alignment_ratio
-
+        elif not args.symmetric_map_align_thresholds and alignment_ratio >= args.aligned_threshold:
+            return cl_id, nm_hits,  error_rate_sum, s1_alignment, s2_alignment, alignment_ratio
+        
     return  best_cluster_id, 0,  -1, -1, -1, alignment_ratio
 
 def eprint(*args, **kwargs):
@@ -279,7 +286,7 @@ def reads_to_clusters(clusters, representatives, sorted_reads, p_emp_probs, mini
         
         # 2. Find the homopolymer compressed error rate (else statement is the only one active in single core mode)
 
-        if len(representatives[read_cl_id]) == 7: # we have already computed homopolymenr compressed error rate in previous iteration (if isONclust is called with multiple cores):
+        if len(representatives[read_cl_id]) == 8: # we have already computed homopolymenr compressed error rate in previous iteration (if isONclust is called with multiple cores):
             lst = list(representatives[read_cl_id])
             lst[1] = new_batch_index
             t = tuple(lst)
@@ -310,7 +317,7 @@ def reads_to_clusters(clusters, representatives, sorted_reads, p_emp_probs, mini
             # compute the average error rate after compression
             poisson_mean = sum([ qualcomp.count(char_) * phred_char_to_p[char_] for char_ in set(qualcomp)])
             h_pol_compr_error_rate = poisson_mean/float(len(qualcomp))
-            representatives[read_cl_id] = (read_cl_id, new_batch_index, acc, seq, qual, score, h_pol_compr_error_rate) # adding homopolymenr compressed error rate to info tuple of cluster origin sequence
+            representatives[read_cl_id] = (read_cl_id, new_batch_index, acc, seq, qual, score, h_pol_compr_error_rate, seq_hpol_comp) # adding homopolymenr compressed error rate to info tuple of cluster origin sequence
 
 
         # 3. Find all the representatives with shared minimizers (this is the time consuming function for noisy and large datasets)

--- a/modules/cluster.py
+++ b/modules/cluster.py
@@ -121,7 +121,7 @@ def get_best_cluster(read_cl_id, compressed_seq_len, hit_clusters_ids, hit_clust
                 rep_mapped_ratio = total_mapped / float(len(rep_compressed_seq))
 
                 if args.symmetric_map_align_thresholds and min(mapped_ratio, rep_mapped_ratio) > args.mapped_threshold:
-                    return cl_id, nm_hits, mapped_ratio
+                    return cl_id, nm_hits, min(mapped_ratio, rep_mapped_ratio)
                 elif not args.symmetric_map_align_thresholds and mapped_ratio > args.mapped_threshold:
                     return cl_id, nm_hits, mapped_ratio
 
@@ -203,7 +203,7 @@ def get_best_cluster_block_align(read_cl_id, representatives, hit_clusters_ids, 
         (s1, s2, (s1_alignment, s2_alignment, alignment_ratio, target_alignment_ratio)) = parasail_block_alignment(seq, c_seq, args.k, match_id_tailored, opening_penalty = gap_opening_penalty,  )
         # print("Expected errors:", poisson_mean, poisson_mean2)
         if args.symmetric_map_align_thresholds and min(alignment_ratio, target_alignment_ratio) >= args.aligned_threshold:
-            return cl_id, nm_hits,  error_rate_sum, s1_alignment, s2_alignment, alignment_ratio
+            return cl_id, nm_hits,  error_rate_sum, s1_alignment, s2_alignment, min(alignment_ratio, target_alignment_ratio)
         elif not args.symmetric_map_align_thresholds and alignment_ratio >= args.aligned_threshold:
             return cl_id, nm_hits,  error_rate_sum, s1_alignment, s2_alignment, alignment_ratio
         

--- a/modules/parallelize.py
+++ b/modules/parallelize.py
@@ -96,7 +96,7 @@ def print_intermediate_results(clusters, cluster_seq_origin, args, iter_nr):
 
     origins_outfile = open(os.path.join(path,  "cluster_origins.csv"), "w")
     for cl_id, all_read_acc in sorted(clusters.items(), key = lambda x: len(x[1]), reverse=True):
-        read_cl_id, b_i, acc, c_seq, c_qual, score, error_rate = cluster_seq_origin[cl_id]
+        read_cl_id, b_i, acc, c_seq, c_qual, score, error_rate, _ = cluster_seq_origin[cl_id]
         origins_outfile.write("{0}\t{1}\t{2}\t{3}\t{4}\t{5}\n".format(read_cl_id, acc, c_seq, c_qual, score, error_rate)) 
     outfile.close()
     origins_outfile.close()
@@ -180,7 +180,7 @@ def parallel_clustering(read_array, p_emp_probs, args):
 
         all_clusters = merge_dicts(*all_cl)
         all_representatives = merge_dicts(*all_repr)
-        read_array =  [ (i, b_index, acc, seq, qual, score) for i, (i, b_index, acc, seq, qual, score, error_rate) in sorted(all_representatives.items(), key=lambda x: x[1][5], reverse=True)] 
+        read_array =  [ (i, b_index, acc, seq, qual, score) for i, (i, b_index, acc, seq, qual, score, error_rate, _) in sorted(all_representatives.items(), key=lambda x: x[1][5], reverse=True)]
         new_nr_repr = len(read_array)
         print("number of representatives left to cluster:", new_nr_repr)
         print("Time elapesd joining clusters:", time() - start_joining)


### PR DESCRIPTION
Applies --mapped_threshold and --aligned_threshold symmetrically, i.e., to both the fraction of the read which matches the cluster representative, and to the fraction of the cluster representative which matches the read. This is useful for cases where there are long, high-quality reads which contain insertions which are not representative of most of the reads in the cluster.  The default behavior without this option does not penalize deletions from the cluster representative.