### PR TITLE
Optimize speed by not invoking medaka a second time when nothing has changed

### DIFF
--- a/NGSpeciesID
+++ b/NGSpeciesID
@@ -147,9 +147,10 @@ def main(args):
         centers_polished = consensus.polish_sequences(centers_filtered, args)
 
         if args.primer_file or args.remove_universal_tails: # check if barcode is found after polishing with medaka
-            barcode_trimmer.remove_barcodes(centers_polished, barcodes, args)
-            centers_filtered = consensus.detect_reverse_complements(centers_polished, args.rc_identity_threshold)
-            centers_polished = consensus.polish_sequences(centers_filtered, args)
+            centers_updated = barcode_trimmer.remove_barcodes(centers_polished, barcodes, args)
+            if centers_updated:
+                centers_filtered = consensus.detect_reverse_complements(centers_polished, args.rc_identity_threshold)
+                centers_polished = consensus.polish_sequences(centers_filtered, args)
 
 
         print("removing temporary workdir")

--- a/modules/barcode_trimmer.py
+++ b/modules/barcode_trimmer.py
@@ -63,7 +63,8 @@ def remove_barcodes(centers, barcodes, args):
         Modifies consensus sequences by copping of at barcode sites.
         This implies changing the datastructure centers with the modified consensus sequeces
     """
-    
+
+    centers_updated = False
     for i, (nr_reads_in_cluster, c_id, center, reads_path_name) in enumerate(centers):
 
         # if consensus is smaller than 2*trim_window we set trim window to half the sequence
@@ -91,11 +92,16 @@ def remove_barcodes(centers, barcodes, args):
                 if start < earliest_hit:
                     earliest_hit = start
             cut_end = len(center) - (trim_window - earliest_hit)
-        center = center[cut_start: cut_end]
 
-        print(center, "NEW")
-        print("cut start", cut_start, "cut end", cut_end)
-        centers[i][2] = center
+        if cut_start > 0 or cut_end < len(center):
+            center = center[cut_start: cut_end]
+
+            print(center, "NEW")
+            print("cut start", cut_start, "cut end", cut_end)
+            centers[i][2] = center
+            centers_updated = True
+
+    return centers_updated
 
     ## Old code scanned all consensus and were prone to errors due to cutting directionality (befause of fwd or rev comp hits of the adapter)
     # for i, (nr_reads_in_cluster, c_id, center, reads_path_name) in enumerate(centers):


### PR DESCRIPTION
On our data set, medaka accounts for a significant portion of the total NGSpeciesID runtime.

For a short .fastq with 50 reads and 3 centers, this optimization reduces runtime on my test machine by 47%

For a longer .fastq with 3099 reads and 1 center, this optimization reduces runtime on my test machine by 25% 

The second medaka invocation does slightly modify the consensus sequences.  On my test set I have the following:

> Alignment identity between first Medaka consensus and second Medaka consensus:
>
>   1.000: 678
>   0.999: 34
>   0.998: 3
>   0.997: 4
>   0.996: 3
>   0.995: 1
>   0.994: 1
>   0.991: 1
> 

I have not added a command line option to select this behavior, to avoid clutter.  But if desired, I can update the PR to do so.